### PR TITLE
Add tests in phpa

### DIFF
--- a/spec/config_files/graphite-config.yaml
+++ b/spec/config_files/graphite-config.yaml
@@ -1,0 +1,33 @@
+version: 'v1'
+kind: 'PHPAConfig'
+verbose: 'true'
+dryRun: 'true'
+# cool down time(in seconds) after performing an action
+actionCooldown: '300'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+# info used to manipulate the k8s object/deployments
+deployment:
+  name: 'backend-staging-deployment'
+  namespace: 'default'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'server_capacity'
+  # positive means if metrics value is great then threshold then it's good and
+  # we should scale down
+  # negative means if metrics value is great then threshold then it's bad and we should
+  # scale up
+  # if metric value falls under metricThreshold +/- metricMargin the do nothing
+  metricType: 'negative'
+  metricThreshold: '32'
+  metricMargin: '16'
+# used to select and get metrics from metric_server
+metricServer:
+  adaptor: 'graphite'
+  graphite:
+    host: 'graphite-server'
+    port: '8030'
+    query: "target=summarize(production.kafka-lag.kafka-cluster-1.topics.*.production_*.lag, '1min', 'avg', false)&from=-10min&until=now&format=json"

--- a/spec/config_files/influx-config.yaml
+++ b/spec/config_files/influx-config.yaml
@@ -1,0 +1,32 @@
+version: 'v1'
+kind: 'PHPAConfig'
+# info used to manipulate the k8s object/deployments
+verbose: 'true'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+deployment:
+  name: 'backend-staging-deployment'
+  namespace: 'backend-app'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'puma_pool_capacity'
+  # positive means if metrics value is greater then threshold
+  # then it's good and we should scale down
+  # negative means if metrics value is greater then threshold
+  # then it's bad and we should scale up
+  # if metric value falls in range Threshold +- margin then do nothing
+  metricType: 'positive'
+  metricThreshold: '16'
+  metricMargin: '8'
+metricServer:
+  adaptor: 'influxdb'
+  influxdb:
+    host: 'influx-db-server'
+    port: '8086'
+    username: ''
+    password: ''
+    database: 'puma_server_stats'
+    query: "SELECT mean(\"pool_capacity\") FROM \"puma\" WHERE (\"env\" = 'staging') AND time >= now() - 10m GROUP BY time(3m)"

--- a/spec/config_files/invalid-influx-config.yaml
+++ b/spec/config_files/invalid-influx-config.yaml
@@ -1,0 +1,32 @@
+version: 'v1'
+kind: 'Config'
+# info used to manipulate the k8s object/deployments
+verbose: 'true'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+deployment:
+  name: 'backend-staging-deployment'
+  namespace: 'backend-app'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'puma_pool_capacity'
+  # positive means if metrics value is greater then threshold
+  # then it's good and we should scale down
+  # negative means if metrics value is greater then threshold
+  # then it's bad and we should scale up
+  # if metric value falls in range Threshold +- margin then do nothing
+  metricType: 'positive'
+  metricThreshold: '16'
+  metricMargin: '8'
+metricServer:
+  adaptor: 'influxdb'
+  influxdb:
+    host: 'influx-db-server'
+    port: '8086'
+    username: ''
+    password: ''
+    database: 'puma_server_stats'
+    query: "SELECT mean(\"pool_capacity\") FROM \"puma\" WHERE (\"env\" = 'staging') AND time >= now() - 10m GROUP BY time(3m)"

--- a/spec/decision_spec.rb
+++ b/spec/decision_spec.rb
@@ -1,0 +1,61 @@
+require 'rspec'
+
+require_relative '../lib/kubernetes_runner.rb'
+
+describe 'decision' do
+  context 'when the metric is positive' do
+    before(:each) do
+      @runner = PHPA::KubernetesRunner.new('spec/config_files/influx-config.yaml')
+      @config = @runner.config
+    end
+
+    it 'decision to scale down is taken when current metrics are more than threshold' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(25)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:scale_down)
+    end
+
+    it 'decision to do nothing is taken when current metrics is in allowed range' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(10)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:do_nothing)
+    end
+
+    it 'decision to scale up is taken when current metrics are more than the threshold' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(7)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:scale_up)
+    end
+  end
+
+  context 'when the metric is negative' do
+    before(:each) do
+      @runner = PHPA::KubernetesRunner.new('spec/config_files/graphite-config.yaml')
+      @config = @runner.config
+    end
+
+    it 'decision to scale up is taken when current metrics are more than threshold' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(50)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:scale_up)
+    end
+
+    it 'decision to do nothing is taken when the current metric is in allowed range' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(30)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:do_nothing)
+    end
+
+    it 'decision to scale up is taken when the current metric is less than the threshold' do
+      expect_any_instance_of(PHPA::KubernetesRunner).to receive(:current_metric_value)\
+        .with(anything).and_return(5)
+      action = @runner.send('decide', @config)
+      expect(action).to eq(:scale_down)
+    end
+  end
+end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -4,7 +4,7 @@ require_relative '../lib/influx.rb'
 require_relative '../lib/kubernetes_runner.rb'
 require_relative '../lib/errors.rb'
 require_relative '../lib/helper.rb'
-require_relative '../lib/../lib/cli.rb'
+require_relative '../lib/cli.rb'
 
 describe 'errors' do
   include PHPA::Helper

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -29,6 +29,12 @@ describe 'errors' do
     expect { PHPA::CLI.new(Shellwords.split('./phpa-cli')) }.to raise_error(PHPA::InvalidConfig)
   end
 
+  it 'test that InvalidConfig exception is raised when kind in config file is not PHPAConfig' do
+    expect do
+      PHPA::CLI.new(Shellwords.split('./phpa-cli spec/config_files/invalid-influx-config.yaml'))
+    end.to raise_error(PHPA::InvalidConfig)
+  end
+
   it 'test that CommandFailed exception is raised when command execution fails' do
     expect { execute_command('kubectl sth') }.to raise_error(PHPA::CommandFailed)
   end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,35 @@
+require 'rspec'
+
+require_relative '../lib/influx.rb'
+require_relative '../lib/kubernetes_runner.rb'
+require_relative '../lib/errors.rb'
+require_relative '../lib/helper.rb'
+require_relative '../lib/../lib/cli.rb'
+
+describe 'errors' do
+  include PHPA::Helper
+
+  it 'test that MetricFetchFailed exception is raised' do
+    runner = PHPA::KubernetesRunner.new('spec/config_files/influx-config.yaml')
+    config = runner.config.server[runner.config.adaptor]
+    expect(InfluxDB::Client).to receive(:new).with(config[:database],
+                                                   host: config[:host],
+                                                   port: config[:port],
+                                                   username: config[:username],
+                                                   password: config[:password],
+                                                   retry: 20).and_raise(StandardError)
+    expect { PHPA::Influx.get_metric(config) }.to raise_error(PHPA::MetricFetchFailed)
+  end
+
+  it 'test that UnknownAdaptor exception is raised' do
+    expect { metric_server_class('xyz') }.to raise_error(PHPA::UnknownAdaptor)
+  end
+
+  it 'test that InvalidConfig exception is raised when no config file is provided' do
+    expect { PHPA::CLI.new(Shellwords.split('./phpa-cli')) }.to raise_error(PHPA::InvalidConfig)
+  end
+
+  it 'test that CommandFailed exception is raised when command execution fails' do
+    expect { execute_command('kubectl sth') }.to raise_error(PHPA::CommandFailed)
+  end
+end


### PR DESCRIPTION
This PR adds tests to check that correct decision are taken in different scenarios.
The cases considered for both positive and negative metric types are:
- the metric value is above the threshold
- the metric value is in the allowed range
- the metric value is below the threshold 

It also verifies that the errors are raised when they should.