### PR TITLE
Require correct permissions for updated Kubernetes version

### DIFF
--- a/setup-access.yaml
+++ b/setup-access.yaml
@@ -19,7 +19,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: phpa-cluster-role
 rules:
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources: ["deployments", "deployments/scale"]
   verbs: ["get", "list", "watch", "update", "patch"]
 ---


### PR DESCRIPTION
Kubernetes version >= 1.16 has moved deployments to apps api group
extensions.