### PR TITLE
fix: processes count set according to runners Fixes #12

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -51,7 +51,7 @@ module PHPA
       # so k8s will relocate autoscaler(PHPA) to scale down node pool
       log_txt "Sleeping on boot for #{BOOT_SLEEP_TIME} seconds..."
       sleep BOOT_SLEEP_TIME
-      Parallel.each(runners) do |runner|
+      Parallel.each(runners, in_process: runners.length) do |runner|
         loop do
           deployment = runner.config.deploy_name
           interval = runner.config.interval

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -51,7 +51,7 @@ module PHPA
       # so k8s will relocate autoscaler(PHPA) to scale down node pool
       log_txt "Sleeping on boot for #{BOOT_SLEEP_TIME} seconds..."
       sleep BOOT_SLEEP_TIME
-      Parallel.each(runners, in_process: runners.length) do |runner|
+      Parallel.each(runners, in_processes: runners.length) do |runner|
         loop do
           deployment = runner.config.deploy_name
           interval = runner.config.interval


### PR DESCRIPTION
Please see the issue description in #12 

An alternative implementation could be to use `in_threads` instead of `in_processes`.