### PR TITLE
ft(app): Add support for other controllers

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -47,21 +47,22 @@ module PHPA
       # build runners from config files and keep looping over them
       runners = runners(config_files)
       # we need to sleep on boot because sometimes autoscaler(PHPA) will scale down
-      # a deployment, and after that autoscaler(PHPA) will be the only pod running
+      # a controller, and after that autoscaler(PHPA) will be the only pod running
       # so k8s will relocate autoscaler(PHPA) to scale down node pool
       log_txt "Sleeping on boot for #{BOOT_SLEEP_TIME} seconds..."
       sleep BOOT_SLEEP_TIME
       Parallel.each(runners) do |runner|
         loop do
-          deployment = runner.config.deploy_name
+          controller_name = runner.config.controller_name
+          controller = runner.config.controller
           interval = runner.config.interval
-          acquire_lock(deployment)
+          acquire_lock(controller_name, controller)
           result = runner.act
-          release_lock(deployment)
+          release_lock(controller_name, controller)
           cooldown = result[:cooldown]
-          log_txt "#{deployment} deployment cooldown: sleeping " \
+          log_txt "#{controller_name} #{controller} cooldown: sleeping " \
             "for #{cooldown} seconds"
-          log_txt "#{deployment} deployment Sleeping for #{interval} seconds"
+          log_txt "#{controller_name} #{controller} Sleeping for #{interval} seconds"
           sleep interval + cooldown
         end
       end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -8,7 +8,7 @@ require_relative 'helper'
 
 module PHPA
   class Config
-    SUPPORTED_CONTROLLERS = %i[deployment job statefulset].freeze
+    SUPPORTED_CONTROLLERS = %i[deployment replicaset statefulset].freeze
     DEFAULT_INTERVAL = 300 # seconds
     DEFAULT_ACTION_COOLDOWN = 60 # seconds
     RETRY_SLEEP_INCREMENT = 2 # seconds

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -8,6 +8,7 @@ require_relative 'helper'
 
 module PHPA
   class Config
+    SUPPORTED_CONTROLLERS = %i[deployment job statefulset].freeze
     DEFAULT_INTERVAL = 300 # seconds
     DEFAULT_ACTION_COOLDOWN = 60 # seconds
     RETRY_SLEEP_INCREMENT = 2 # seconds
@@ -22,7 +23,7 @@ module PHPA
                   :deploy_name, :namespace, :adaptor, :server, \
                   :min_replicas, :max_replicas, :fallback_replicas, \
                   :metric_name, :metric_type, :metric_threshold, :metric_margin, \
-                  :interval, :fallback_enabled
+                  :interval, :fallback_enabled, :controller, :controller_name
 
     def initialize(file_path)
       config = YAML.load_file(file_path)
@@ -41,16 +42,26 @@ module PHPA
       interval = config[:interval] || DEFAULT_INTERVAL
       @interval = interval.to_i
       @version = config[:version]
-
-      @deploy_name = config[:deployment][:name]
-      @namespace = config[:deployment][:namespace]
-
       @server = config[:metricServer]
       @adaptor = config[:metricServer][:adaptor].to_sym
 
-      @min_replicas = config[:deployment][:minReplicas].to_i
-      @max_replicas = config[:deployment][:maxReplicas].to_i
-      @fallback_replicas = config[:deployment][:fallbackReplicas].to_i
+      controllers = SUPPORTED_CONTROLLERS & config.keys
+      # TODO: the wording could be better ?
+      if controllers.count > 1
+        raise InvalidConfig,
+              "We currently support only one controller per config. We observe #{controllers.join('&')}"
+      elsif controllers.count < 1
+        raise InvalidConfig,
+              "We expect exactly one controller per config. Found None."
+      end
+      @controller = controllers.first
+      @controller_name = config[@controller][:name]
+      # Deprecation Warning.
+      @deploy_name = @controller_name if @controller == :deployment
+      @namespace = config[@controller][:namespace]
+      @min_replicas = config[@controller][:minReplicas].to_i
+      @max_replicas = config[@controller][:maxReplicas].to_i
+      @fallback_replicas = config[@controller][:fallbackReplicas].to_i
 
       @metric_name = config[:metric][:name]
       @metric_type = config[:metric][:metricType].to_sym
@@ -58,6 +69,7 @@ module PHPA
       @metric_margin = config[:metric][:metricMargin].to_f
 
       if @verbose
+        # Use a logger instead
         puts "=== Config: #{file_path} ==="
         ap config
       end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -46,14 +46,14 @@ module PHPA
       FileUtils.mkdir_p(Config::LOCK_DIR)
     end
 
-    def lock_file_path(deployment_name)
-      return "#{Config::LOCK_DIR}/#{deployment_name}.lock"
+    def lock_file_path(controller_name, controller)
+      return "#{Config::LOCK_DIR}/#{controller}_#{controller_name}.lock"
     end
 
-    def acquire_lock(deployment_name)
+    def acquire_lock(controller_name, controller)
       create_lock_dir
       # exit if lockfile already exits
-      lock_file = lock_file_path(deployment_name)
+      lock_file = lock_file_path(controller_name, controller)
       if File.exist?(lock_file)
         log_txt "ERR: Lockfile #{lock_file} already exits"
         exit(1)
@@ -64,8 +64,8 @@ module PHPA
       lockfile.close
     end
 
-    def release_lock(deployment_name)
-      lock_file = lock_file_path(deployment_name)
+    def release_lock(controller_name, controller)
+      lock_file = lock_file_path(controller_name, controller)
       File.delete(lock_file)
     end
 
@@ -82,17 +82,19 @@ module PHPA
     end
 
     # helper methods to interact with k8s
-    def current_replicas(deployment, scope)
+    def current_replicas(controller, controller_name, scope)
       sleep_dur = 1
       Config::REPLICA_RETRY.times do
-        command = "kubectl get deploy #{deployment} -o yaml #{scope}"
+        # TODO: we can probably get this value without having to parse the entire
+        #       YAML
+        command = "kubectl get #{controller} #{controller_name} -o yaml #{scope}"
         stdout = execute_command(command, verbose: false)
         yaml = YAML.load(stdout).deep_symbolize_keys!
         result = yaml[:status][:replicas]
         return result if result.present?
 
         sleep_dur += Config::RETRY_SLEEP_INCREMENT
-        log_txt "current_replicas for '#{deployment}' is sleeping for #{sleep_dur}s"
+        log_txt "current_replicas for #{controller}:#{controller_name} is sleeping for #{sleep_dur}s"
         sleep sleep_dur
       end
     rescue CommandFailed => e
@@ -110,11 +112,11 @@ module PHPA
       return (min..max).cover?(scale_to)
     end
 
-    def scale_it(deployment, scope, replicas)
-      command = "kubectl scale deployment #{deployment} --replicas=#{replicas} #{scope}"
+    def scale_it(controller, controller_name, scope, replicas)
+      command = "kubectl scale #{controller} #{controller_name} --replicas=#{replicas} #{scope}"
       execute_command(command)
     rescue CommandFailed => e
-      log_txt "Failed to scale #{deployment}"
+      log_txt "Failed to scale #{controller}:#{controller_name}"
       print_backtrace(e)
     end
   end

--- a/lib/kubernetes_runner.rb
+++ b/lib/kubernetes_runner.rb
@@ -33,7 +33,7 @@ module PHPA
       scope = "--namespace=#{config.namespace}"
       min = config.min_replicas
       max = config.max_replicas
-      current = current_replicas(controller_name, controller, scope)
+      current = current_replicas(controller, controller_name , scope)
       log_txt "current_replicas: #{current} on #{controller}:#{controller_name}" if config.verbose
       action = :no_current_replicas if current.blank?
 
@@ -72,7 +72,7 @@ module PHPA
 
       if can_scale?(min, max, scale_to)
         log_txt "scaling #{controller}:#{controller_name} to #{scale_to} replicas #{msg}"
-        scale_it(controller_name, controller, scope, scale_to) unless config.dry_run
+        scale_it(controller, controller_name, scope, scale_to) unless config.dry_run
         result[:scaled] = true
         result[:cooldown] = config.action_cooldown
       else

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,0 +1,47 @@
+require 'rspec'
+
+require_relative '../lib/cli'
+require_relative '../lib/kubernetes_runner'
+
+describe 'command' do
+  context 'When statefulsets are used' do
+    before(:each) do
+      @controller = PHPA::Config::SUPPORTED_CONTROLLERS.sample
+      @runner = PHPA::KubernetesRunner.new("spec/config_files/#{@controller}.yaml")
+      @config = @runner.config
+    end
+
+    it 'generates the correct commands' do
+      # scale up
+      current_replicas_mock = double(YAML)
+      current_replicas_response = { 'status' => { 'replicas' => 1 } }
+      allow(@runner).to receive(:current_metric_value).and_return(80)
+      expect(@runner).to receive(:execute_command).with(
+        "kubectl get #{@controller} query-db -o yaml --namespace=query-db", verbose: false
+      ).and_return(current_replicas_mock)
+      allow(YAML).to receive(:load).with(current_replicas_mock).and_return(current_replicas_response)
+      expect(@runner).to receive(:execute_command).with("kubectl scale #{@controller} query-db --replicas=2 --namespace=query-db")
+      @runner.act
+
+      # do nothing
+      current_replicas_response = { 'status' => { 'replicas' => 2 } }
+      allow(@runner).to receive(:current_metric_value).and_return(55)
+      expect(@runner).to receive(:execute_command).with(
+        "kubectl get #{@controller} query-db -o yaml --namespace=query-db", verbose: false
+      ).and_return(current_replicas_mock)
+      allow(YAML).to receive(:load).with(current_replicas_mock).and_return(current_replicas_response)
+      expect(@runner).not_to receive(:execute_command).with("kubectl scale #{@controller} query-db --replicas=3 --namespace=query-db")
+      @runner.act
+
+      # scale down
+      current_replicas_response = { 'status' => { 'replicas' => 2 } }
+      allow(@runner).to receive(:current_metric_value).and_return(10)
+      expect(@runner).to receive(:execute_command).with(
+        "kubectl get #{@controller} query-db -o yaml --namespace=query-db", verbose: false
+      ).and_return(current_replicas_mock)
+      allow(YAML).to receive(:load).with(current_replicas_mock).and_return(current_replicas_response)
+      expect(@runner).not_to receive(:execute_command).with("kubectl scale #{@controller} query-db --replicas=2 --namespace=query-db")
+      @runner.act
+    end
+  end
+end

--- a/spec/config_files/deployment.yaml
+++ b/spec/config_files/deployment.yaml
@@ -1,0 +1,28 @@
+version: 'v1'
+kind: 'PHPAConfig'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+deployment:
+  name: 'query-db'
+  namespace: 'query-db'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'query_volume'
+  # negative means if metrics value is greater then threshold
+  # then should scale up
+  # if metric value falls in range Threshold +- margin then do nothing
+  metricType: 'negative'
+  metricThreshold: '40'
+  metricMargin: '20'
+metricServer:
+  adaptor: 'graphite'
+  influxdb:
+    host: 'graphite-db-server'
+    port: '30080'
+    username: 'elden_ping'
+    password: 'grace'
+    database: 'tosoft'
+    query: "sumSeries(summarize(production.query-db.instance-*.query.total.volume, '5min', 'p95', false))&from=-15min&until=now"

--- a/spec/config_files/replicaset.yaml
+++ b/spec/config_files/replicaset.yaml
@@ -1,0 +1,28 @@
+version: 'v1'
+kind: 'PHPAConfig'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+replicaset:
+  name: 'query-db'
+  namespace: 'query-db'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'query_volume'
+  # negative means if metrics value is greater then threshold
+  # then should scale up
+  # if metric value falls in range Threshold +- margin then do nothing
+  metricType: 'negative'
+  metricThreshold: '40'
+  metricMargin: '20'
+metricServer:
+  adaptor: 'graphite'
+  influxdb:
+    host: 'graphite-db-server'
+    port: '30080'
+    username: 'elden_ping'
+    password: 'grace'
+    database: 'tosoft'
+    query: "sumSeries(summarize(production.query-db.instance-*.query.total.volume, '5min', 'p95', false))&from=-15min&until=now"

--- a/spec/config_files/statefulset.yaml
+++ b/spec/config_files/statefulset.yaml
@@ -1,0 +1,28 @@
+version: 'v1'
+kind: 'PHPAConfig'
+# interval (in seconds) between consecutive checks of phpa for this deployment
+interval: '300'
+statefulset:
+  name: 'query-db'
+  namespace: 'query-db'
+  minReplicas: '1'
+  maxReplicas: '4'
+  fallbackReplicas: '2'
+metric:
+  # name of metric, used to know what these configs are
+  name: 'query_volume'
+  # negative means if metrics value is greater then threshold
+  # then should scale up
+  # if metric value falls in range Threshold +- margin then do nothing
+  metricType: 'negative'
+  metricThreshold: '40'
+  metricMargin: '20'
+metricServer:
+  adaptor: 'graphite'
+  influxdb:
+    host: 'graphite-db-server'
+    port: '30080'
+    username: 'elden_ping'
+    password: 'grace'
+    database: 'tosoft'
+    query: "sumSeries(summarize(production.query-db.instance-*.query.total.volume, '5min', 'p95', false))&from=-15min&until=now"


### PR DESCRIPTION
* The ability to 'scale' exists for all controllers:
  * job
  * deployment
  * stateful
  out of which only `deployment` was currently supported. The
  `kubectl` protocol to scale controllers follows the same pattern
  so it is relatively easier to perform this upgrade.
* Certain attributes like:
  * deploy_name
  will need to be deprecated since this is now applies to all
  controllers. All of the changes made were intended to be graceful
  and not breaking.
* `lock_acquisition`is now scoped by the `controller`. Since the locks
  are relevant only when the process is running and an upgrade will not
  be attempted while it is running - it was deemed fine to make this
  change.
* TODOS:
  * a proper logger is required (not in this PR) to:
    * scope log messages 
    * maintain a certain pattern
    * consider variance in verbosity.
  * Add tests (This PR)
  * Alternative/efficient ways of getting the replica count (Not in this PR)