### PR TITLE
Fix current replicas count to give correct number

### DIFF
--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -97,6 +97,7 @@ module PHPA
         log_txt "current_replicas for '#{deployment}' is sleeping for #{sleep_dur}s"
         sleep sleep_dur
       end
+      return 0
     rescue CommandFailed => e
       print_backtrace(e)
       # return nil to indicate that we failed to fetch current replica count


### PR DESCRIPTION
When the deployment has no replicas running, the `current_replicas` is expected to return 0, but instead it returns `6` (which is `Config::REPLICA_RETRY`) due to a minor bug.