### PR TITLE
Cooldown and interval are not additive

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -62,7 +62,7 @@ module PHPA
           log_txt "#{deployment} deployment cooldown: sleeping " \
             "for #{cooldown} seconds"
           log_txt "#{deployment} deployment Sleeping for #{interval} seconds"
-          sleep interval + cooldown
+          sleep [interval, cooldown].max
         end
       end
     end


### PR DESCRIPTION
When an action cooldown comes into effect, it should not delay the next check for action beyond the maximum value of cooldown or interval. Earlier, cooldown and interval were additive. This change takes a max of the two.